### PR TITLE
missing disarm timeout monitor after connection refused

### DIFF
--- a/lib/Predis/Async/Connection/StreamConnection.php
+++ b/lib/Predis/Async/Connection/StreamConnection.php
@@ -280,7 +280,7 @@ class StreamConnection implements ConnectionInterface
         if (stream_socket_get_name($socket, true) === false) {
             $this->disconnect();
             $this->onError(new ConnectionException($this, "Connection refused"));
-
+            $this->disarmTimeoutMonitor();
             return false;
         }
 


### PR DESCRIPTION
This issue will cause the 'Connection timed out' error will also be raised even though a 'Connection refused' error raised before.
